### PR TITLE
Feature/library_search: Add Search functionality in Library Screen

### DIFF
--- a/app/src/main/java/com/example/fitjournal/core/domain/utils/filtering/Filter.kt
+++ b/app/src/main/java/com/example/fitjournal/core/domain/utils/filtering/Filter.kt
@@ -1,0 +1,16 @@
+package com.example.fitjournal.core.domain.utils.filtering
+
+import java.util.SortedMap
+
+/**
+ * Filters the list for the specified string
+ * Then groups the list according to the first character.
+ * Finally, converts to a sorted map and returns that map
+ **/
+fun searchForText(text: String, list: List<String>): SortedMap<Char, List<String>> {
+    return list.filter {
+        it.lowercase().contains(text.lowercase())
+    }.groupBy {
+        it.first()
+    }.toSortedMap()
+}

--- a/app/src/main/java/com/example/fitjournal/core/presentation/commoncomponents/textField/SearchBar.kt
+++ b/app/src/main/java/com/example/fitjournal/core/presentation/commoncomponents/textField/SearchBar.kt
@@ -68,7 +68,7 @@ fun SearchBar(
                 Icon(
                     imageVector = Icons.Default.Clear,
                     contentDescription = null,
-                    tint = determineFocusColor(isFocused = isTextFieldFocused),
+                    tint = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.clickable {
                         clearSearch()
                     }

--- a/app/src/main/java/com/example/fitjournal/core/presentation/commoncomponents/textField/SearchBar.kt
+++ b/app/src/main/java/com/example/fitjournal/core/presentation/commoncomponents/textField/SearchBar.kt
@@ -59,7 +59,7 @@ fun SearchBar(
         leadingIcon = {
             Icon(
                 imageVector = Icons.Default.Search,
-                contentDescription = null,
+                contentDescription = stringResource(id = R.string.content_desc_search_icon),
                 tint = determineFocusColor(isFocused = isTextFieldFocused)
             )
         },
@@ -67,7 +67,7 @@ fun SearchBar(
             if (searchedTerm.isNotEmpty()) {
                 Icon(
                     imageVector = Icons.Default.Clear,
-                    contentDescription = null,
+                    contentDescription = stringResource(id = R.string.content_desc_cancel_icon_clear_text),
                     tint = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.clickable {
                         clearSearch()

--- a/app/src/main/java/com/example/fitjournal/core/presentation/commoncomponents/textField/SearchBar.kt
+++ b/app/src/main/java/com/example/fitjournal/core/presentation/commoncomponents/textField/SearchBar.kt
@@ -2,12 +2,14 @@ package com.example.fitjournal.core.presentation.commoncomponents.textField
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -34,6 +36,7 @@ import com.example.fitjournal.core.presentation.utils.determineFocusColor
 fun SearchBar(
     searchedTerm: String,
     updateSearchBarText: (String) -> Unit,
+    clearSearch: () -> Unit,
     keyboardController: SoftwareKeyboardController?,
     focusManager: FocusManager
 ) {
@@ -59,6 +62,18 @@ fun SearchBar(
                 contentDescription = null,
                 tint = determineFocusColor(isFocused = isTextFieldFocused)
             )
+        },
+        trailingIcon = {
+            if (searchedTerm.isNotEmpty()) {
+                Icon(
+                    imageVector = Icons.Default.Clear,
+                    contentDescription = null,
+                    tint = determineFocusColor(isFocused = isTextFieldFocused),
+                    modifier = Modifier.clickable {
+                        clearSearch()
+                    }
+                )
+            }
         },
         colors = TextFieldDefaults.colors(
             focusedContainerColor = MaterialTheme.colorScheme.surface,

--- a/app/src/main/java/com/example/fitjournal/core/presentation/commoncomponents/textField/SearchBar.kt
+++ b/app/src/main/java/com/example/fitjournal/core/presentation/commoncomponents/textField/SearchBar.kt
@@ -35,7 +35,7 @@ import com.example.fitjournal.core.presentation.utils.determineFocusColor
 @Composable
 fun SearchBar(
     searchedTerm: String,
-    updateSearchBarText: (String) -> Unit,
+    updateSearch: (String) -> Unit,
     clearSearch: () -> Unit,
     keyboardController: SoftwareKeyboardController?,
     focusManager: FocusManager
@@ -44,7 +44,7 @@ fun SearchBar(
     TextField(
         value = searchedTerm,
         onValueChange = { searchBarText ->
-            updateSearchBarText(
+            updateSearch(
                 searchBarText
             )
         },

--- a/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/LibraryScreen.kt
@@ -49,6 +49,11 @@ fun LibraryScreen(
                     LibraryWorkoutClickEvents.UpdateSearchBarText(searchedText)
                 )
             },
+            clearSearch = {
+                libraryWorkoutState.handleLibraryWorkoutClickEvents(
+                    LibraryWorkoutClickEvents.ClearSearchBarText
+                )
+            },
             keyboardController = keyboardController,
             focusManager = focusManager
         )

--- a/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/LibraryScreen.kt
@@ -44,9 +44,9 @@ fun LibraryScreen(
     ) {
         SearchBar(
             searchedTerm = libraryWorkoutState.searchedTerm,
-            updateSearchBarText = { searchedText ->
+            updateSearch = { searchedText ->
                 libraryWorkoutState.handleLibraryWorkoutClickEvents(
-                    LibraryWorkoutClickEvents.UpdateSearchBarText(searchedText)
+                    LibraryWorkoutClickEvents.UpdateSearch(searchedText)
                 )
             },
             clearSearch = {

--- a/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/LibraryScreen.kt
@@ -51,7 +51,7 @@ fun LibraryScreen(
             },
             clearSearch = {
                 libraryWorkoutState.handleLibraryWorkoutClickEvents(
-                    LibraryWorkoutClickEvents.ClearSearchBarText
+                    LibraryWorkoutClickEvents.ClearSearch
                 )
             },
             keyboardController = keyboardController,

--- a/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/LibraryScreenViewModel.kt
+++ b/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/LibraryScreenViewModel.kt
@@ -66,7 +66,8 @@ class LibraryScreenViewModel @Inject constructor() : ViewModel() {
 
     private fun clearSearchBarText() {
         libraryWorkoutState = libraryWorkoutState.copy(
-            searchedTerm = ""
+            searchedTerm = "",
+            listOfSearchedWorkouts = libraryWorkoutState.masterWorkoutList
         )
     }
 }

--- a/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/LibraryScreenViewModel.kt
+++ b/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/LibraryScreenViewModel.kt
@@ -31,7 +31,7 @@ class LibraryScreenViewModel @Inject constructor() : ViewModel() {
 
     private fun handleLibraryWorkoutEvents(event: LibraryWorkoutClickEvents) {
         when (event) {
-            LibraryWorkoutClickEvents.ClearSearchBarText -> clearSearchBarText()
+            LibraryWorkoutClickEvents.ClearSearch -> clearSearch()
             is LibraryWorkoutClickEvents.UpdateSearchBarText -> {
                 updateSearchBarText(event.text)
                 updateSearchedWorkouts(event.text)
@@ -64,7 +64,7 @@ class LibraryScreenViewModel @Inject constructor() : ViewModel() {
         )
     }
 
-    private fun clearSearchBarText() {
+    private fun clearSearch() {
         libraryWorkoutState = libraryWorkoutState.copy(
             searchedTerm = "",
             listOfSearchedWorkouts = libraryWorkoutState.masterWorkoutList

--- a/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/LibraryScreenViewModel.kt
+++ b/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/LibraryScreenViewModel.kt
@@ -6,9 +6,10 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import com.example.fitjournal.core.data.mockdata.MockData.libraryWorkoutList
 import com.example.fitjournal.library.presentation.screen.library.model.LibraryWorkoutClickEvents
-import com.example.fitjournal.library.presentation.screen.library.model.LibraryWorkoutItem
 import com.example.fitjournal.library.presentation.screen.library.model.LibraryWorkoutUiModel
 import com.example.fitjournal.library.presentation.screen.library.model.WorkoutCategory
+import com.example.fitjournal.library.presentation.screen.library.utils.mapToLibraryUiList
+import com.example.fitjournal.library.presentation.screen.library.utils.searchForText
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -24,29 +25,35 @@ class LibraryScreenViewModel @Inject constructor() : ViewModel() {
     init {
         // Dummy Data for now
         val workoutMap = libraryWorkoutList.groupBy { it.first() }.toSortedMap()
-        val masterWorkoutList = workoutMap.map { workouts ->
-            WorkoutCategory(
-                name = workouts.key.toString(),
-                items = workouts.value.map { workout ->
-                    LibraryWorkoutItem(
-                        workoutName = workout,
-                        workoutDetails = "Details for $workout go here"
-                    )
-                }
-            )
-        }
+        val masterWorkoutList = mapToLibraryUiList(workoutMap)
         setMasterListOfWorkouts(masterWorkoutList)
     }
 
     private fun handleLibraryWorkoutEvents(event: LibraryWorkoutClickEvents) {
         when (event) {
             LibraryWorkoutClickEvents.ClearSearchBarText -> clearSearchBarText()
-            is LibraryWorkoutClickEvents.UpdateSearchBarText -> updateSearchBarText(event.text)
+            is LibraryWorkoutClickEvents.UpdateSearchBarText -> {
+                updateSearchBarText(event.text)
+                updateSearchedWorkouts(event.text)
+            }
         }
     }
+
+    private fun updateSearchedWorkouts(text: String) {
+        val filteredList = searchForText(text)
+        val uiList = mapToLibraryUiList(filteredList)
+        setListOfSearchedWorkouts(uiList)
+    }
+
     private fun setMasterListOfWorkouts(workoutList: List<WorkoutCategory>) {
         libraryWorkoutState = libraryWorkoutState.copy(
             masterWorkoutList = workoutList,
+            listOfSearchedWorkouts = workoutList
+        )
+    }
+
+    private fun setListOfSearchedWorkouts(workoutList: List<WorkoutCategory>) {
+        libraryWorkoutState = libraryWorkoutState.copy(
             listOfSearchedWorkouts = workoutList
         )
     }

--- a/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/LibraryScreenViewModel.kt
+++ b/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/LibraryScreenViewModel.kt
@@ -5,11 +5,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import com.example.fitjournal.core.data.mockdata.MockData.libraryWorkoutList
+import com.example.fitjournal.core.domain.utils.filtering.searchForText
 import com.example.fitjournal.library.presentation.screen.library.model.LibraryWorkoutClickEvents
 import com.example.fitjournal.library.presentation.screen.library.model.LibraryWorkoutUiModel
 import com.example.fitjournal.library.presentation.screen.library.model.WorkoutCategory
 import com.example.fitjournal.library.presentation.screen.library.utils.mapToLibraryUiList
-import com.example.fitjournal.library.presentation.screen.library.utils.searchForText
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -32,7 +32,7 @@ class LibraryScreenViewModel @Inject constructor() : ViewModel() {
     private fun handleLibraryWorkoutEvents(event: LibraryWorkoutClickEvents) {
         when (event) {
             LibraryWorkoutClickEvents.ClearSearch -> clearSearch()
-            is LibraryWorkoutClickEvents.UpdateSearchBarText -> {
+            is LibraryWorkoutClickEvents.UpdateSearch -> {
                 updateSearchBarText(event.text)
                 updateSearchedWorkouts(event.text)
             }
@@ -40,7 +40,7 @@ class LibraryScreenViewModel @Inject constructor() : ViewModel() {
     }
 
     private fun updateSearchedWorkouts(text: String) {
-        val filteredList = searchForText(text)
+        val filteredList = searchForText(text, libraryWorkoutList)
         val uiList = mapToLibraryUiList(filteredList)
         setListOfSearchedWorkouts(uiList)
     }

--- a/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/components/ExerciseItem.kt
+++ b/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/components/ExerciseItem.kt
@@ -30,7 +30,7 @@ fun ExerciseItem(exercise: String) {
 }
 
 @Composable
-private fun ExerciseName(exercise: String){
+private fun ExerciseName(exercise: String) {
     Text(
         text = exercise,
         color = MaterialTheme.colorScheme.onPrimary,

--- a/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/model/LibraryWorkoutClickEvents.kt
+++ b/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/model/LibraryWorkoutClickEvents.kt
@@ -2,5 +2,5 @@ package com.example.fitjournal.library.presentation.screen.library.model
 
 sealed class LibraryWorkoutClickEvents {
     data class UpdateSearchBarText(val text: String) : LibraryWorkoutClickEvents()
-    data object ClearSearchBarText : LibraryWorkoutClickEvents()
+    data object ClearSearch : LibraryWorkoutClickEvents()
 }

--- a/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/model/LibraryWorkoutClickEvents.kt
+++ b/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/model/LibraryWorkoutClickEvents.kt
@@ -1,6 +1,6 @@
 package com.example.fitjournal.library.presentation.screen.library.model
 
 sealed class LibraryWorkoutClickEvents {
-    data class UpdateSearchBarText(val text: String) : LibraryWorkoutClickEvents()
+    data class UpdateSearch(val text: String) : LibraryWorkoutClickEvents()
     data object ClearSearch : LibraryWorkoutClickEvents()
 }

--- a/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/utils/LibrarySearch.kt
+++ b/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/utils/LibrarySearch.kt
@@ -1,0 +1,29 @@
+package com.example.fitjournal.library.presentation.screen.library.utils
+
+import com.example.fitjournal.core.data.mockdata.MockData
+import com.example.fitjournal.library.presentation.screen.library.model.LibraryWorkoutItem
+import com.example.fitjournal.library.presentation.screen.library.model.WorkoutCategory
+import java.util.SortedMap
+
+fun searchForText(text: String): SortedMap<Char, List<String>> {
+    return MockData.libraryWorkoutList
+        .filter {
+            it.lowercase().contains(text.lowercase())
+        }.groupBy {
+            it.first()
+        }.toSortedMap()
+}
+
+fun mapToLibraryUiList(workoutMap: SortedMap<Char, List<String>>): List<WorkoutCategory> {
+    return workoutMap.map { workouts ->
+        WorkoutCategory(
+            name = workouts.key.toString(),
+            items = workouts.value.map { workout ->
+                LibraryWorkoutItem(
+                    workoutName = workout,
+                    workoutDetails = "Details for $workout go here"
+                )
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/utils/LibrarySearch.kt
+++ b/app/src/main/java/com/example/fitjournal/library/presentation/screen/library/utils/LibrarySearch.kt
@@ -1,18 +1,8 @@
 package com.example.fitjournal.library.presentation.screen.library.utils
 
-import com.example.fitjournal.core.data.mockdata.MockData
 import com.example.fitjournal.library.presentation.screen.library.model.LibraryWorkoutItem
 import com.example.fitjournal.library.presentation.screen.library.model.WorkoutCategory
 import java.util.SortedMap
-
-fun searchForText(text: String): SortedMap<Char, List<String>> {
-    return MockData.libraryWorkoutList
-        .filter {
-            it.lowercase().contains(text.lowercase())
-        }.groupBy {
-            it.first()
-        }.toSortedMap()
-}
 
 fun mapToLibraryUiList(workoutMap: SortedMap<Char, List<String>>): List<WorkoutCategory> {
     return workoutMap.map { workouts ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="content_desc_bottom_app_bar_home_icon">Home tab to view workouts for the day</string>
     <string name="content_desc_bottom_app_bar_library_icon">Library for choosing workouts</string>
     <string name="content_desc_cancel_icon_clear_text">An x to clear text in searchbar</string>
+    <string name="content_desc_search_icon">A magnifying glass that signifies a user\'s ability to search workouts within this search bar</string>
 
     // Title Strings
     <string name="title_filter_workouts">Filter Your Workouts</string>


### PR DESCRIPTION
## Feature/library_search: Add Search functionality in Library Screen

## Bug/Feature description
User is now able to search their list of workouts for a specific term. They can also clear the text in search bar and reset the list of items in their workout list to their original state.

## Solution description
Filtered the mock list of strings and see if they contain the searched term. Then I mapped the filtered list to the models needed to display on the UI.

## Code Validations 
[x] PR is under 400 lines of code Insertion and Deletion  
[x] Files are Formatted and Optimized  
[x] Clean Architecture followed  
[x] No unneccessary comments or TODOs left in codebase  
[ ] Unit Tests Added  
[ ] Unit Tests NOT added and explanation why under exemption description  
[ ] UI Tests Added  
[ ] UI Tests NOT added and explanation why under exemption description  
[ ] End to End Tests Added  
[ ] End to End Tests NOT added and explanation why under exemption description  
[x] Screenshot of UI added  

## Exemption Definition
Explain if necessary the reason for any exemptions

## UI Screenshots 
Searching Term with clear button now displaying:
![image](https://github.com/Alex-A-Fit/FitJournal-Android/assets/18683870/e2ef96fc-02d5-4add-96bd-db3c68969921)

Clicking Clear resets the state: 
![image](https://github.com/Alex-A-Fit/FitJournal-Android/assets/18683870/7b2717cd-b180-4582-b1f8-a923269f0f95)

## Test Case Screenshots
Place test Success creations here
