### PR TITLE
Feature/Adjust Home Screen UI

### DIFF
--- a/app/src/main/java/com/example/fitjournal/MainActivity.kt
+++ b/app/src/main/java/com/example/fitjournal/MainActivity.kt
@@ -495,14 +495,14 @@ fun navigateToDestination(
         )
     }
 
-    NavigationInterface.NavigateToJournalEntry -> {
+    NavigationInterface.NavigateToAddWorkout -> {
         navigationEvent(
             navigationInterface = navigationInterface,
             navController = navController
         )
     }
 
-    is NavigationInterface.NavigateToJournalEntryDetails -> {
+    is NavigationInterface.NavigateToAddWorkoutDetails -> {
         navigationEvent(
             navigationInterface = navigationInterface,
             navController = navController

--- a/app/src/main/java/com/example/fitjournal/MainActivity.kt
+++ b/app/src/main/java/com/example/fitjournal/MainActivity.kt
@@ -296,7 +296,7 @@ class MainActivity : ComponentActivity() {
                                 navController = navController
                             )
                         }
-                        composable(Route.ADD_WORKOUT_SCREEN) {
+                        composable("${Route.ADD_WORKOUT_SCREEN}${Arguments.WORKOUT_DATE}") { backStackEntry ->
                             LaunchedEffect(Unit) {
                                 bottomBarVisibility.value = false
                             }
@@ -307,14 +307,15 @@ class MainActivity : ComponentActivity() {
                                 mainScreen = { mainModifier ->
                                     AddWorkoutScreen(
                                         modifier = mainModifier,
-                                        journalEntryState = addWorkoutViewModel.journalEntryState,
+                                        addWorkoutUiState = addWorkoutViewModel.journalEntryState,
                                         navigateToDestination = {
                                             showChildFabs = false
                                             navigateToDestination(
                                                 navigationInterface = it,
                                                 navController = navController
                                             )
-                                        }
+                                        },
+                                        workoutDate = backStackEntry.arguments?.getString("workoutDate") ?: ""
                                     )
                                 },
                                 topAppBar = {
@@ -337,13 +338,15 @@ class MainActivity : ComponentActivity() {
                                 bottomBarVisibility = bottomBarVisibility.value
                             )
                         }
-                        composable("${Route.ADD_WORKOUT_DETAILS_SCREEN}${Arguments.WORKOUT_NAME}${Arguments.WORKOUT_TYPE}") { backStackEntry ->
+                        composable("${Route.ADD_WORKOUT_DETAILS_SCREEN}${Arguments.WORKOUT_NAME}${Arguments.WORKOUT_TYPE}${Arguments.WORKOUT_DATE}") { backStackEntry ->
                             LaunchedEffect(Unit) {
                                 bottomBarVisibility.value = false
-                                addWorkoutDetailViewModel.addWorkoutNameAndType(
+                                addWorkoutDetailViewModel.addNavigationArguments(
                                     workoutName = backStackEntry.arguments?.getString("workoutName")
                                         ?: "",
                                     workoutType = backStackEntry.arguments?.getString("workoutType")
+                                        ?: "",
+                                    workoutDate = backStackEntry.arguments?.getString("workoutDate")
                                         ?: ""
                                 )
                             }
@@ -495,7 +498,7 @@ fun navigateToDestination(
         )
     }
 
-    NavigationInterface.NavigateToAddWorkout -> {
+    is NavigationInterface.NavigateToAddWorkout -> {
         navigationEvent(
             navigationInterface = navigationInterface,
             navController = navController

--- a/app/src/main/java/com/example/fitjournal/MainActivity.kt
+++ b/app/src/main/java/com/example/fitjournal/MainActivity.kt
@@ -41,6 +41,7 @@ import com.example.fitjournal.core.presentation.screens.lottie.LottieHomeScreenA
 import com.example.fitjournal.core.presentation.theme.FitJournalTheme
 import com.example.fitjournal.home.presentation.components.appbar.EditWorkoutTopAppBar
 import com.example.fitjournal.home.presentation.components.appbar.HomeTopAppBar
+import com.example.fitjournal.home.presentation.model.events.HomeScreenEvents
 import com.example.fitjournal.home.presentation.screen.editworkout.EditWorkoutScreen
 import com.example.fitjournal.home.presentation.screen.editworkout.EditWorkoutViewModel
 import com.example.fitjournal.home.presentation.screen.home.HomeScreen
@@ -66,7 +67,13 @@ class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        mainViewModel.runSplashScreen()
+        mainViewModel.getDataFromRealm(
+            getDataFromRealmForHomeScreen = {
+                homeViewModel.homeScreenState.homeScreenEvents(
+                    HomeScreenEvents.CollectRealmWorkoutEntryFromDb
+                )
+            }
+        )
         setContent {
             FitJournalTheme {
                 val navController = rememberNavController()
@@ -159,7 +166,6 @@ class MainActivity : ComponentActivity() {
                         composable(Route.HOME_SCREEN) {
                             LaunchedEffect(Unit) {
                                 bottomBarVisibility.value = true
-                                homeViewModel.clearUiState()
                             }
                             AppScreen(
                                 showChildrenFabIcons = showChildFabs,
@@ -400,7 +406,6 @@ class MainActivity : ComponentActivity() {
                         }
                         composable(LOTTIE_INTRO) {
                             LottieHomeScreenAnimation(
-                                mainActivityState = mainViewModel.appScreenState,
                                 navController = navController
                             )
                         }

--- a/app/src/main/java/com/example/fitjournal/MainViewModel.kt
+++ b/app/src/main/java/com/example/fitjournal/MainViewModel.kt
@@ -37,11 +37,10 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    fun runSplashScreen() {
-        viewModelScope.launch {
-            delay(2000L)
-            appScreenState = MainActivityUiState.Success
-        }
+    fun getDataFromRealm(
+        getDataFromRealmForHomeScreen: () -> Unit
+    ) {
+        getDataFromRealmForHomeScreen()
     }
 
     fun addWorkoutToLibraryDatabase(

--- a/app/src/main/java/com/example/fitjournal/MainViewModel.kt
+++ b/app/src/main/java/com/example/fitjournal/MainViewModel.kt
@@ -11,7 +11,6 @@ import com.example.fitjournal.core.domain.usecase.realm.workout.RealmWorkoutEntr
 import com.example.fitjournal.core.presentation.model.enums.WorkoutTypeEnum
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 

--- a/app/src/main/java/com/example/fitjournal/addWorkout/model/AddWorkoutUiModel.kt
+++ b/app/src/main/java/com/example/fitjournal/addWorkout/model/AddWorkoutUiModel.kt
@@ -2,12 +2,12 @@ package com.example.fitjournal.addWorkout.model
 
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.snapshots.SnapshotStateList
-import com.example.fitjournal.addWorkout.model.events.JournalEntryEvents
+import com.example.fitjournal.addWorkout.model.events.AddWorkoutEvents
 import com.example.fitjournal.library.presentation.screen.library.model.WorkoutCategory
 
-data class JournalEntryUiModel(
+data class AddWorkoutUiModel(
     val masterWorkoutList: List<WorkoutCategory> = emptyList(),
     val listOfSearchedWorkouts: SnapshotStateList<WorkoutCategory> = mutableStateListOf(),
     val searchedTerm: String = "",
-    val handleJournalEntryClickEvents: (JournalEntryEvents) -> Unit
+    val handleJournalEntryClickEvents: (AddWorkoutEvents) -> Unit
 )

--- a/app/src/main/java/com/example/fitjournal/addWorkout/model/events/AddWorkoutEvents.kt
+++ b/app/src/main/java/com/example/fitjournal/addWorkout/model/events/AddWorkoutEvents.kt
@@ -1,0 +1,6 @@
+package com.example.fitjournal.addWorkout.model.events
+
+sealed class AddWorkoutEvents {
+    data object ClearSearchBarFilter : AddWorkoutEvents()
+    data class FilterSearchByWorkout(val workout: String) : AddWorkoutEvents()
+}

--- a/app/src/main/java/com/example/fitjournal/addWorkout/model/events/JournalEntryEvents.kt
+++ b/app/src/main/java/com/example/fitjournal/addWorkout/model/events/JournalEntryEvents.kt
@@ -1,6 +1,0 @@
-package com.example.fitjournal.addWorkout.model.events
-
-sealed class JournalEntryEvents {
-    data object ClearSearchBarFilter : JournalEntryEvents()
-    data class FilterSearchByWorkout(val workout: String) : JournalEntryEvents()
-}

--- a/app/src/main/java/com/example/fitjournal/addWorkout/screen/addworkout/AddWorkoutScreen.kt
+++ b/app/src/main/java/com/example/fitjournal/addWorkout/screen/addworkout/AddWorkoutScreen.kt
@@ -62,7 +62,7 @@ fun AddWorkoutScreen(
         UserWorkoutList(
             workoutList = journalEntryState.listOfSearchedWorkouts,
             selectedWorkout = { name, type ->
-                navigateToDestination(NavigationInterface.NavigateToJournalEntryDetails(name, type))
+                navigateToDestination(NavigationInterface.NavigateToAddWorkoutDetails(name, type))
             }
         )
     }

--- a/app/src/main/java/com/example/fitjournal/addWorkout/screen/addworkout/AddWorkoutScreen.kt
+++ b/app/src/main/java/com/example/fitjournal/addWorkout/screen/addworkout/AddWorkoutScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -13,8 +14,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import com.example.fitjournal.addWorkout.components.UserWorkoutList
-import com.example.fitjournal.addWorkout.model.JournalEntryUiModel
-import com.example.fitjournal.addWorkout.model.events.JournalEntryEvents
+import com.example.fitjournal.addWorkout.model.AddWorkoutUiModel
+import com.example.fitjournal.addWorkout.model.events.AddWorkoutEvents
 import com.example.fitjournal.core.presentation.commoncomponents.textField.SearchBar
 import com.example.fitjournal.core.presentation.navigation.NavigationInterface
 import com.example.fitjournal.core.presentation.theme.Spacing
@@ -22,12 +23,17 @@ import com.example.fitjournal.core.presentation.theme.Spacing
 @Composable
 fun AddWorkoutScreen(
     modifier: Modifier,
-    journalEntryState: JournalEntryUiModel,
+    addWorkoutUiState: AddWorkoutUiModel,
+    workoutDate: String,
     navigateToDestination: (NavigationInterface) -> Unit
 ) {
-    val searchText = rememberSaveable(journalEntryState.searchedTerm) {
-        mutableStateOf(journalEntryState.searchedTerm)
+    val searchText = rememberSaveable(addWorkoutUiState.searchedTerm) {
+        mutableStateOf(addWorkoutUiState.searchedTerm)
     }
+    val date by rememberSaveable(workoutDate) {
+        mutableStateOf(workoutDate)
+    }
+
     val focusManager = LocalFocusManager.current
     val interactionSource = remember { MutableInteractionSource() }
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -47,22 +53,22 @@ fun AddWorkoutScreen(
         SearchBar(
             searchedTerm = searchText.value,
             updateSearch = { searchedText ->
-                journalEntryState.handleJournalEntryClickEvents(
-                    JournalEntryEvents.FilterSearchByWorkout(
+                addWorkoutUiState.handleJournalEntryClickEvents(
+                    AddWorkoutEvents.FilterSearchByWorkout(
                         searchedText
                     )
                 )
             },
             clearSearch = {
-                journalEntryState.handleJournalEntryClickEvents(JournalEntryEvents.ClearSearchBarFilter)
+                addWorkoutUiState.handleJournalEntryClickEvents(AddWorkoutEvents.ClearSearchBarFilter)
             },
             keyboardController = keyboardController,
             focusManager = focusManager
         )
         UserWorkoutList(
-            workoutList = journalEntryState.listOfSearchedWorkouts,
+            workoutList = addWorkoutUiState.listOfSearchedWorkouts,
             selectedWorkout = { name, type ->
-                navigateToDestination(NavigationInterface.NavigateToAddWorkoutDetails(name, type))
+                navigateToDestination(NavigationInterface.NavigateToAddWorkoutDetails(name, type, date))
             }
         )
     }

--- a/app/src/main/java/com/example/fitjournal/addWorkout/screen/addworkout/AddWorkoutViewModel.kt
+++ b/app/src/main/java/com/example/fitjournal/addWorkout/screen/addworkout/AddWorkoutViewModel.kt
@@ -1,16 +1,13 @@
 package com.example.fitjournal.addWorkout.screen.addworkout
 
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.toMutableStateList
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.fitjournal.addWorkout.model.JournalEntryUiModel
-import com.example.fitjournal.addWorkout.model.events.JournalEntryEvents
-import com.example.fitjournal.core.data.mockdata.MockData
-import com.example.fitjournal.core.data.model.realmdb.library.RealmWorkoutLibrary
+import com.example.fitjournal.addWorkout.model.AddWorkoutUiModel
+import com.example.fitjournal.addWorkout.model.events.AddWorkoutEvents
 import com.example.fitjournal.core.domain.usecase.realm.library.RealmWorkoutLibraryUseCase
 import com.example.fitjournal.core.util.filter.searchForText
 import com.example.fitjournal.library.presentation.screen.library.utils.mapToLibraryUiList
@@ -22,12 +19,8 @@ import javax.inject.Inject
 class AddWorkoutViewModel @Inject constructor(
     private val realmWorkoutLibraryUseCase: RealmWorkoutLibraryUseCase
 ) : ViewModel() {
-
-    private val workoutList = MockData.mockLibraryList
-
-    var selectedWorkoutDetail: MutableState<RealmWorkoutLibrary?> = mutableStateOf(null)
     var journalEntryState by mutableStateOf(
-        JournalEntryUiModel(
+        AddWorkoutUiModel(
             handleJournalEntryClickEvents = ::journalClickEvents
         )
     )
@@ -37,9 +30,9 @@ class AddWorkoutViewModel @Inject constructor(
         getDataFromRealmDb()
     }
 
-    private fun journalClickEvents(event: JournalEntryEvents) {
+    private fun journalClickEvents(event: AddWorkoutEvents) {
         when (event) {
-            is JournalEntryEvents.FilterSearchByWorkout -> {
+            is AddWorkoutEvents.FilterSearchByWorkout -> {
                 val filteredList = searchForText(
                     event.workout,
                     journalEntryState.masterWorkoutList
@@ -52,7 +45,7 @@ class AddWorkoutViewModel @Inject constructor(
                 )
             }
 
-            JournalEntryEvents.ClearSearchBarFilter -> {
+            AddWorkoutEvents.ClearSearchBarFilter -> {
                 updateJournalEntryState(
                     newJournalEntryState = journalEntryState.copy(
                         listOfSearchedWorkouts = journalEntryState.masterWorkoutList.toMutableStateList(),
@@ -86,7 +79,7 @@ class AddWorkoutViewModel @Inject constructor(
         }
     }
 
-    private fun updateJournalEntryState(newJournalEntryState: JournalEntryUiModel) {
+    private fun updateJournalEntryState(newJournalEntryState: AddWorkoutUiModel) {
         journalEntryState = newJournalEntryState
     }
 }

--- a/app/src/main/java/com/example/fitjournal/addWorkout/screen/addworkout/details/AddWorkoutDetailViewModel.kt
+++ b/app/src/main/java/com/example/fitjournal/addWorkout/screen/addworkout/details/AddWorkoutDetailViewModel.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import org.mongodb.kbson.ObjectId
+import java.time.LocalDate
 import java.time.ZoneOffset
 import javax.inject.Inject
 
@@ -281,7 +282,9 @@ class AddWorkoutDetailViewModel @Inject constructor(
                     workoutName = addWorkoutDetailUiState.workoutName,
                     workoutType = addWorkoutDetailUiState.workoutType,
                     workoutTypeEnum = addWorkoutDetailUiState.workoutTypeEnum,
-                    addWorkoutDetailEvents = ::journalEntryDetailsEvents
+                    addWorkoutDetailEvents = ::journalEntryDetailsEvents,
+                    localDate = addWorkoutDetailUiState.localDate,
+                    localDateInMillis = addWorkoutDetailUiState.localDateInMillis
                 )
             }
 
@@ -689,12 +692,19 @@ class AddWorkoutDetailViewModel @Inject constructor(
         }
     }
 
-    fun addWorkoutNameAndType(workoutName: String, workoutType: String) {
+    fun addNavigationArguments(
+        workoutName: String,
+        workoutType: String,
+        workoutDate: String
+    ) {
+        val date = LocalDate.parse(workoutDate, DateManager.getCommonDateFormat())
         updateWorkoutState(
             newAddWorkoutDetailUiState = addWorkoutDetailUiState.copy(
                 workoutName = workoutName,
                 workoutType = workoutType,
-                workoutTypeEnum = getWorkoutType(workoutType)
+                workoutTypeEnum = getWorkoutType(workoutType),
+                localDate = date.format(DateManager.getCommonDateFormat()),
+                localDateInMillis = (date.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli())
             )
         )
     }

--- a/app/src/main/java/com/example/fitjournal/core/data/di/AppModule.kt
+++ b/app/src/main/java/com/example/fitjournal/core/data/di/AppModule.kt
@@ -17,6 +17,7 @@ import com.example.fitjournal.core.domain.usecase.realm.workout.DeleteWorkoutEnt
 import com.example.fitjournal.core.domain.usecase.realm.workout.GetRealmWorkoutEntryList
 import com.example.fitjournal.core.domain.usecase.realm.workout.GetSingleRealmWorkoutEntry
 import com.example.fitjournal.core.domain.usecase.realm.workout.RealmWorkoutEntryUseCase
+import com.example.fitjournal.core.domain.usecase.realm.workout.SyncDbWithViewModelUseCase
 import com.example.fitjournal.core.domain.usecase.realm.workout.UpdateSingleWorkoutEntryToRealmDbUseCase
 import com.example.fitjournal.core.domain.usecase.workout.AddOrSubtractDoublesUseCase
 import com.example.fitjournal.core.domain.usecase.workout.AddOrSubtractIntegersUseCase
@@ -70,6 +71,9 @@ object AppModule {
                 realmWorkoutEntryRepository = realmWorkoutEntryRepository
             ),
             getSingleRealmWorkoutEntry = GetSingleRealmWorkoutEntry(
+                realmWorkoutEntryRepository = realmWorkoutEntryRepository
+            ),
+            SyncDbWithViewModelUseCase = SyncDbWithViewModelUseCase(
                 realmWorkoutEntryRepository = realmWorkoutEntryRepository
             )
         )

--- a/app/src/main/java/com/example/fitjournal/core/data/repository/RealmWorkoutEntryRepositoryImpl.kt
+++ b/app/src/main/java/com/example/fitjournal/core/data/repository/RealmWorkoutEntryRepositoryImpl.kt
@@ -16,6 +16,8 @@ import javax.inject.Inject
 class RealmWorkoutEntryRepositoryImpl @Inject constructor() : RealmWorkoutEntryRepository {
     private val realm = FitJournal.realm
 
+    override var shouldViewModelFetchRealmData: Boolean = false
+
     override suspend fun addMockDataToRealm() {
         // this is how we would write workout to realm db
         realm.write {
@@ -67,6 +69,7 @@ class RealmWorkoutEntryRepositoryImpl @Inject constructor() : RealmWorkoutEntryR
         return realm.write {
             return@write try {
                 copyToRealm(realmWorkoutEntry, updatePolicy = UpdatePolicy.ALL)
+                shouldViewModelFetchRealmData = true
                 true
             } catch (e: IllegalArgumentException) {
                 // catch for copyToRealm() in case it throws error
@@ -93,6 +96,7 @@ class RealmWorkoutEntryRepositoryImpl @Inject constructor() : RealmWorkoutEntryR
                     originalRealmWorkoutEntry.workout = updatedRealmWorkoutEntry.workout
                     originalRealmWorkoutEntry.timeStamp = updatedRealmWorkoutEntry.timeStamp
                     copyToRealm(originalRealmWorkoutEntry, updatePolicy = UpdatePolicy.ALL)
+                    shouldViewModelFetchRealmData = true
                     wasUpdateSuccessful = true
                 } else {
                     wasUpdateSuccessful = false
@@ -119,6 +123,7 @@ class RealmWorkoutEntryRepositoryImpl @Inject constructor() : RealmWorkoutEntryR
                 ).also {
                     wasWorkoutDeleted = if (it != null) {
                         delete(it)
+                        shouldViewModelFetchRealmData = true
                         true
                     } else {
                         false
@@ -133,6 +138,10 @@ class RealmWorkoutEntryRepositoryImpl @Inject constructor() : RealmWorkoutEntryR
                 false
             }
         }
+    }
+
+    override fun updateShouldViewModelFetchRealmData(shouldFetch: Boolean) {
+        shouldViewModelFetchRealmData = shouldFetch
     }
 
     private fun createWorkoutId(): String {

--- a/app/src/main/java/com/example/fitjournal/core/domain/mapper/WorkoutModelToWorkoutUiModelMapper.kt
+++ b/app/src/main/java/com/example/fitjournal/core/domain/mapper/WorkoutModelToWorkoutUiModelMapper.kt
@@ -83,17 +83,19 @@ fun WorkoutModel.mapToWorkoutUiModel(): WorkoutUiModel {
                                 hours += it.time?.hours?.toIntOrZero() ?: 0
                                 minutes += it.time?.minutes?.toIntOrZero() ?: 0
                                 seconds += it.time?.seconds?.toIntOrZero() ?: 0
-                                weight += when (it.weightType.stringConcatenatedValue) {
-                                    "kgs" -> {
-                                        (it.weight?.times(KILOGRAMS_TO_POUNDS_CONVERSION_FACTOR)) ?: 0.0
-                                    }
-
-                                    "lbs" -> {
-                                        it.weight ?: 0.0
-                                    }
-
-                                    else -> 0.0
-                                }
+                                // removing weight until a better statistic can be established
+//                                weight += when (it.weightType.stringConcatenatedValue) {
+//                                    "kgs" -> {
+//                                        val newWeight = (it.weight?.times(KILOGRAMS_TO_POUNDS_CONVERSION_FACTOR)) ?: 0.0
+//                                        newWeight * it.reps * it.sets
+//                                    }
+//
+//                                    "lbs" -> {
+//                                        (it.weight ?: 0.0) * it.reps * it.sets
+//                                    }
+//
+//                                    else -> 0.0
+//                                }
                             }
                             CalisthenicsModel(
                                 reps = reps,

--- a/app/src/main/java/com/example/fitjournal/core/domain/repository/RealmWorkoutEntryRepository.kt
+++ b/app/src/main/java/com/example/fitjournal/core/domain/repository/RealmWorkoutEntryRepository.kt
@@ -3,6 +3,7 @@ package com.example.fitjournal.core.domain.repository
 import com.example.fitjournal.core.data.model.realmdb.workout.RealmWorkoutEntry
 
 interface RealmWorkoutEntryRepository {
+    var shouldViewModelFetchRealmData: Boolean
     suspend fun addMockDataToRealm()
     suspend fun getRealmWorkoutEntryList(): List<RealmWorkoutEntry>
     suspend fun getSingleRealmWorkoutEntry(workoutId: String): RealmWorkoutEntry?
@@ -17,4 +18,6 @@ interface RealmWorkoutEntryRepository {
     suspend fun deleteWorkoutEntryFromRealmDb(
         realmWorkoutId: String
     ): Boolean
+
+    fun updateShouldViewModelFetchRealmData(shouldFetch: Boolean)
 }

--- a/app/src/main/java/com/example/fitjournal/core/domain/usecase/realm/workout/RealmWorkoutEntryUseCase.kt
+++ b/app/src/main/java/com/example/fitjournal/core/domain/usecase/realm/workout/RealmWorkoutEntryUseCase.kt
@@ -18,6 +18,6 @@ data class RealmWorkoutEntryUseCase(
     // DELETE
     val deleteWorkoutEntryFromRealmDbUseCase: DeleteWorkoutEntryFromRealmDbUseCase,
 
-    //Verify if Sync is needed
+    // Verify if Sync is needed
     val SyncDbWithViewModelUseCase: SyncDbWithViewModelUseCase
 )

--- a/app/src/main/java/com/example/fitjournal/core/domain/usecase/realm/workout/RealmWorkoutEntryUseCase.kt
+++ b/app/src/main/java/com/example/fitjournal/core/domain/usecase/realm/workout/RealmWorkoutEntryUseCase.kt
@@ -16,5 +16,8 @@ data class RealmWorkoutEntryUseCase(
     val updateSingleWorkoutEntryToRealmDbUseCase: UpdateSingleWorkoutEntryToRealmDbUseCase,
 
     // DELETE
-    val deleteWorkoutEntryFromRealmDbUseCase: DeleteWorkoutEntryFromRealmDbUseCase
+    val deleteWorkoutEntryFromRealmDbUseCase: DeleteWorkoutEntryFromRealmDbUseCase,
+
+    //Verify if Sync is needed
+    val SyncDbWithViewModelUseCase: SyncDbWithViewModelUseCase
 )

--- a/app/src/main/java/com/example/fitjournal/core/domain/usecase/realm/workout/SyncDbWithViewModelUseCase.kt
+++ b/app/src/main/java/com/example/fitjournal/core/domain/usecase/realm/workout/SyncDbWithViewModelUseCase.kt
@@ -17,5 +17,4 @@ class SyncDbWithViewModelUseCase @Inject constructor(
             false
         }
     }
-
 }

--- a/app/src/main/java/com/example/fitjournal/core/domain/usecase/realm/workout/SyncDbWithViewModelUseCase.kt
+++ b/app/src/main/java/com/example/fitjournal/core/domain/usecase/realm/workout/SyncDbWithViewModelUseCase.kt
@@ -1,0 +1,21 @@
+package com.example.fitjournal.core.domain.usecase.realm.workout
+
+import com.example.fitjournal.core.domain.repository.RealmWorkoutEntryRepository
+import javax.inject.Inject
+
+class SyncDbWithViewModelUseCase @Inject constructor(
+    private val realmWorkoutEntryRepository: RealmWorkoutEntryRepository
+) {
+    // checking to see if we need to fetch new data and updating
+    // the respective boolean if we do fetch to not fetch again
+    operator fun invoke(): Boolean {
+        val shouldSyncOccur = realmWorkoutEntryRepository.shouldViewModelFetchRealmData
+        return if (shouldSyncOccur) {
+            realmWorkoutEntryRepository.updateShouldViewModelFetchRealmData(false)
+            true
+        } else {
+            false
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/fitjournal/core/domain/usecase/realm/workout/SyncDbWithViewModelUseCase.kt
+++ b/app/src/main/java/com/example/fitjournal/core/domain/usecase/realm/workout/SyncDbWithViewModelUseCase.kt
@@ -6,8 +6,8 @@ import javax.inject.Inject
 class SyncDbWithViewModelUseCase @Inject constructor(
     private val realmWorkoutEntryRepository: RealmWorkoutEntryRepository
 ) {
-    // checking to see if we need to fetch new data and updating
-    // the respective boolean if we do fetch to not fetch again
+    // checking to see if we need to fetch new data and if so, updating
+    // the respective boolean on repo side to not fetch again until db changes
     operator fun invoke(): Boolean {
         val shouldSyncOccur = realmWorkoutEntryRepository.shouldViewModelFetchRealmData
         return if (shouldSyncOccur) {

--- a/app/src/main/java/com/example/fitjournal/core/presentation/commoncomponents/buttons/standardbuttons/AddToJournalButton.kt
+++ b/app/src/main/java/com/example/fitjournal/core/presentation/commoncomponents/buttons/standardbuttons/AddToJournalButton.kt
@@ -1,0 +1,42 @@
+package com.example.fitjournal.core.presentation.commoncomponents.buttons.standardbuttons
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import com.example.fitjournal.R
+import com.example.fitjournal.core.presentation.theme.Spacing
+
+@Composable
+fun AddToJournalButton(
+    navigateToAddWorkoutScreen: () -> Unit
+) {
+    Button(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = Spacing.spacing16, horizontal = Spacing.spacing32)
+            .background(
+                color = MaterialTheme.colorScheme.primary,
+                shape = MaterialTheme.shapes.large
+            ),
+        onClick = { navigateToAddWorkoutScreen() }
+    ) {
+        Text(
+            text = stringResource(id = R.string.text_add_to_journal),
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    vertical = Spacing.spacing8,
+                    horizontal = Spacing.spacing16
+                ),
+            textAlign = TextAlign.Center
+        )
+    }
+}

--- a/app/src/main/java/com/example/fitjournal/core/presentation/navigation/NavigationEvent.kt
+++ b/app/src/main/java/com/example/fitjournal/core/presentation/navigation/NavigationEvent.kt
@@ -19,7 +19,7 @@ fun navigationEvent(
             navController.navigate(Route.WORKOUT_STATISTICS_SCREEN)
         }
 
-        NavigationInterface.NavigateToJournalEntry -> {
+        NavigationInterface.NavigateToAddWorkout -> {
             navController.navigate(Route.ADD_WORKOUT_SCREEN)
         }
 
@@ -29,7 +29,7 @@ fun navigationEvent(
             )
         }
 
-        is NavigationInterface.NavigateToJournalEntryDetails -> {
+        is NavigationInterface.NavigateToAddWorkoutDetails -> {
             navController.navigate("${Route.ADD_WORKOUT_DETAILS_SCREEN}/${navigationInterface.workoutName}/${navigationInterface.workoutType}")
         }
     }

--- a/app/src/main/java/com/example/fitjournal/core/presentation/navigation/NavigationEvent.kt
+++ b/app/src/main/java/com/example/fitjournal/core/presentation/navigation/NavigationEvent.kt
@@ -19,8 +19,10 @@ fun navigationEvent(
             navController.navigate(Route.WORKOUT_STATISTICS_SCREEN)
         }
 
-        NavigationInterface.NavigateToAddWorkout -> {
-            navController.navigate(Route.ADD_WORKOUT_SCREEN)
+        is NavigationInterface.NavigateToAddWorkout -> {
+            navController.navigate(
+                "${Route.ADD_WORKOUT_SCREEN}/${navigationInterface.workoutDate}"
+            )
         }
 
         is NavigationInterface.NavigateToEditWorkout -> {
@@ -30,7 +32,7 @@ fun navigationEvent(
         }
 
         is NavigationInterface.NavigateToAddWorkoutDetails -> {
-            navController.navigate("${Route.ADD_WORKOUT_DETAILS_SCREEN}/${navigationInterface.workoutName}/${navigationInterface.workoutType}")
+            navController.navigate("${Route.ADD_WORKOUT_DETAILS_SCREEN}/${navigationInterface.workoutName}/${navigationInterface.workoutType}/${navigationInterface.workoutDate}")
         }
     }
 }

--- a/app/src/main/java/com/example/fitjournal/core/presentation/navigation/NavigationInterface.kt
+++ b/app/src/main/java/com/example/fitjournal/core/presentation/navigation/NavigationInterface.kt
@@ -2,12 +2,13 @@ package com.example.fitjournal.core.presentation.navigation
 
 sealed interface NavigationInterface {
     data object NavigateToHome : NavigationInterface
-    data class NavigateToEditWorkout(val workoutId: String) : NavigationInterface
     data object NavigateToWorkoutLibrary : NavigationInterface
     data object NavigateToWorkoutStatistics : NavigationInterface
-    data object NavigateToAddWorkout : NavigationInterface
+    data class NavigateToEditWorkout(val workoutId: String) : NavigationInterface
+    data class NavigateToAddWorkout(val workoutDate: String) : NavigationInterface
     data class NavigateToAddWorkoutDetails(
         val workoutName: String,
-        val workoutType: String
+        val workoutType: String,
+        val workoutDate: String
     ) : NavigationInterface
 }

--- a/app/src/main/java/com/example/fitjournal/core/presentation/navigation/NavigationInterface.kt
+++ b/app/src/main/java/com/example/fitjournal/core/presentation/navigation/NavigationInterface.kt
@@ -5,8 +5,8 @@ sealed interface NavigationInterface {
     data class NavigateToEditWorkout(val workoutId: String) : NavigationInterface
     data object NavigateToWorkoutLibrary : NavigationInterface
     data object NavigateToWorkoutStatistics : NavigationInterface
-    data object NavigateToJournalEntry : NavigationInterface
-    data class NavigateToJournalEntryDetails(
+    data object NavigateToAddWorkout : NavigationInterface
+    data class NavigateToAddWorkoutDetails(
         val workoutName: String,
         val workoutType: String
     ) : NavigationInterface

--- a/app/src/main/java/com/example/fitjournal/core/presentation/navigation/Route.kt
+++ b/app/src/main/java/com/example/fitjournal/core/presentation/navigation/Route.kt
@@ -14,4 +14,5 @@ object Arguments {
     const val WORKOUT_ID = "/{workoutId}"
     const val WORKOUT_NAME = "/{workoutName}"
     const val WORKOUT_TYPE = "/{workoutType}"
+    const val WORKOUT_DATE = "/{workoutDate}"
 }

--- a/app/src/main/java/com/example/fitjournal/core/presentation/screens/AppScreen.kt
+++ b/app/src/main/java/com/example/fitjournal/core/presentation/screens/AppScreen.kt
@@ -174,7 +174,7 @@ fun AppScreen(
                         },
                         navigateToJournalEntry = {
                             displayChildFabs?.invoke(false)
-                            navigateToDestination(NavigationInterface.NavigateToJournalEntry)
+                            navigateToDestination(NavigationInterface.NavigateToAddWorkout)
                         }
                     )
                     AddWorkoutFab(

--- a/app/src/main/java/com/example/fitjournal/core/presentation/screens/AppScreen.kt
+++ b/app/src/main/java/com/example/fitjournal/core/presentation/screens/AppScreen.kt
@@ -31,8 +31,10 @@ import com.example.fitjournal.core.presentation.commoncomponents.floatingactionb
 import com.example.fitjournal.core.presentation.commoncomponents.floatingactionbutton.AnimatedFabColumn
 import com.example.fitjournal.core.presentation.navigation.NavigationInterface
 import com.example.fitjournal.core.presentation.theme.Spacing
+import com.example.fitjournal.core.util.localdate.formatToCommonDate
 import com.example.fitjournal.library.domain.model.AddWorkoutToLibraryModel
 import com.skydoves.cloudy.Cloudy
+import java.time.LocalDate
 
 @Composable
 fun AppScreen(
@@ -174,7 +176,7 @@ fun AppScreen(
                         },
                         navigateToJournalEntry = {
                             displayChildFabs?.invoke(false)
-                            navigateToDestination(NavigationInterface.NavigateToAddWorkout)
+                            navigateToDestination(NavigationInterface.NavigateToAddWorkout(workoutDate = LocalDate.now().formatToCommonDate()))
                         }
                     )
                     AddWorkoutFab(

--- a/app/src/main/java/com/example/fitjournal/core/presentation/screens/lottie/LottieHomeScreenAnimation.kt
+++ b/app/src/main/java/com/example/fitjournal/core/presentation/screens/lottie/LottieHomeScreenAnimation.kt
@@ -8,7 +8,6 @@ import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition
-import com.example.fitjournal.MainActivityUiState
 import com.example.fitjournal.R
 import com.example.fitjournal.core.presentation.navigation.NavigationInterface
 import com.example.fitjournal.core.presentation.navigation.navigationEvent

--- a/app/src/main/java/com/example/fitjournal/core/presentation/screens/lottie/LottieHomeScreenAnimation.kt
+++ b/app/src/main/java/com/example/fitjournal/core/presentation/screens/lottie/LottieHomeScreenAnimation.kt
@@ -15,7 +15,6 @@ import com.example.fitjournal.core.presentation.navigation.navigationEvent
 
 @Composable
 fun LottieHomeScreenAnimation(
-    mainActivityState: MainActivityUiState,
     navController: NavController
 ) {
     val nightMode = isSystemInDarkTheme()
@@ -29,11 +28,10 @@ fun LottieHomeScreenAnimation(
         composition = composition,
         progress = { progress }
     )
-    when (mainActivityState) {
-        MainActivityUiState.Success -> navigationEvent(
+    if (progress == 1f) {
+        navigationEvent(
             navigationInterface = NavigationInterface.NavigateToHome,
             navController = navController
         )
-        else -> Unit
     }
 }

--- a/app/src/main/java/com/example/fitjournal/home/presentation/components/card/CalisthenicsCard.kt
+++ b/app/src/main/java/com/example/fitjournal/home/presentation/components/card/CalisthenicsCard.kt
@@ -17,7 +17,6 @@ import com.example.fitjournal.core.domain.model.TimeModel
 import com.example.fitjournal.core.presentation.commoncomponents.cards.FitJournalCard
 import com.example.fitjournal.core.presentation.model.enums.EditWorkoutTimeDeterminate
 import com.example.fitjournal.core.presentation.theme.Spacing
-import com.example.fitjournal.core.util.extensions.TwoDecimalOrNoDecimal
 import com.example.fitjournal.core.util.extensions.getTimeForUi
 import com.example.fitjournal.home.presentation.components.card.subcomponents.CalisthenicsSummaryTitle
 import com.example.fitjournal.home.presentation.components.card.subcomponents.CardSeeDetailsText
@@ -52,8 +51,10 @@ fun CalisthenicsCard(
                         .padding(horizontal = Spacing.spacing16),
                     sets = calisthenicsUi.sets?.toString() ?: "",
                     reps = calisthenicsUi.reps?.toString() ?: "",
-                    weight = calisthenicsUi.weight?.toString()?.TwoDecimalOrNoDecimal(),
-                    weightInKgs = calisthenicsUi.weightInKgs.toString().TwoDecimalOrNoDecimal(),
+                    // removing weight until a better statistic can be established
+                    // also see WorkoutModelToWorkoutUiModelMapper for logic on weight
+//                    weight = calisthenicsUi.weight?.toString()?.TwoDecimalOrNoDecimal(),
+//                    weightInKgs = calisthenicsUi.weightInKgs.toString().TwoDecimalOrNoDecimal(),
                     time = calisthenicsUi.time
                 )
             } else {

--- a/app/src/main/java/com/example/fitjournal/home/presentation/screen/home/HomeEmptyScreen.kt
+++ b/app/src/main/java/com/example/fitjournal/home/presentation/screen/home/HomeEmptyScreen.kt
@@ -1,0 +1,50 @@
+package com.example.fitjournal.home.presentation.screen.home
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import com.example.fitjournal.R
+import com.example.fitjournal.core.presentation.commoncomponents.buttons.standardbuttons.AddToJournalButton
+import com.example.fitjournal.core.presentation.theme.Spacing
+
+@Composable
+fun HomeEmptyScreen(
+    modifier: Modifier,
+    navigateToAddWorkoutScreen: () -> Unit
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            painter = painterResource(id = R.drawable.icon_journal),
+            contentDescription = stringResource(id = R.string.content_desc_journal_filled_icon),
+            modifier = Modifier.size(Spacing.spacing128),
+            tint = MaterialTheme.colorScheme.primary
+        )
+        Spacer(modifier = Modifier.height(Spacing.spacing16))
+        Text(
+            text = stringResource(id = R.string.title_no_workouts_added),
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.height(Spacing.spacing16))
+        AddToJournalButton(
+            navigateToAddWorkoutScreen = navigateToAddWorkoutScreen
+        )
+    }
+}

--- a/app/src/main/java/com/example/fitjournal/home/presentation/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/fitjournal/home/presentation/screen/home/HomeScreen.kt
@@ -116,7 +116,7 @@ fun HomeScreen(
                 HomeEmptyScreen(
                     modifier = Modifier.fillMaxSize(),
                     navigateToAddWorkoutScreen = {
-                        navigateToDestination(NavigationInterface.NavigateToAddWorkout)
+                        navigateToDestination(NavigationInterface.NavigateToAddWorkout(workoutDate = homeScreenState.currentDate))
                     }
                 )
             }
@@ -202,7 +202,7 @@ fun HomeScreen(
                     item {
                         AddToJournalButton(
                             navigateToAddWorkoutScreen = {
-                                navigateToDestination(NavigationInterface.NavigateToAddWorkout)
+                                navigateToDestination(NavigationInterface.NavigateToAddWorkout(workoutDate = homeScreenState.currentDate))
                             }
                         )
                         Spacer(modifier = Modifier.height(Spacing.spacing96))

--- a/app/src/main/java/com/example/fitjournal/home/presentation/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/fitjournal/home/presentation/screen/home/HomeScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
@@ -23,9 +24,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.window.DialogProperties
 import com.example.fitjournal.R
+import com.example.fitjournal.core.presentation.commoncomponents.buttons.standardbuttons.AddToJournalButton
 import com.example.fitjournal.core.presentation.commoncomponents.dialogs.FilterWorkoutTypeDialog
 import com.example.fitjournal.core.presentation.model.enums.WorkoutTypeEnum
 import com.example.fitjournal.core.presentation.navigation.NavigationInterface
+import com.example.fitjournal.core.presentation.screens.LoadingScreen
 import com.example.fitjournal.core.presentation.theme.Spacing
 import com.example.fitjournal.core.util.state.UiState
 import com.example.fitjournal.home.presentation.components.card.CalisthenicsCard
@@ -106,13 +109,16 @@ fun HomeScreen(
         }
         when (val workoutList = homeScreenState.listOfVisibleWorkoutsUiState) {
             UiState.Loading, UiState.None -> {
-                // need to provide loading animation of some sorts
-                Unit
+                LoadingScreen()
             }
 
             UiState.Empty, is UiState.Error -> {
-                // need to provide empty state of some sorts for empty and error
-                Unit
+                HomeEmptyScreen(
+                    modifier = Modifier.fillMaxSize(),
+                    navigateToAddWorkoutScreen = {
+                        navigateToDestination(NavigationInterface.NavigateToAddWorkout)
+                    }
+                )
             }
 
             is UiState.Success -> {
@@ -192,6 +198,14 @@ fun HomeScreen(
                             }
                         }
                         Spacer(modifier = Modifier.height(Spacing.spacing12))
+                    }
+                    item {
+                        AddToJournalButton(
+                            navigateToAddWorkoutScreen = {
+                                navigateToDestination(NavigationInterface.NavigateToAddWorkout)
+                            }
+                        )
+                        Spacer(modifier = Modifier.height(Spacing.spacing96))
                     }
                 }
             }

--- a/app/src/main/java/com/example/fitjournal/home/presentation/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/fitjournal/home/presentation/screen/home/HomeScreen.kt
@@ -50,14 +50,8 @@ fun HomeScreen(
     removeBlur: () -> Unit,
     showSnackBar: suspend (String) -> Unit
 ) {
-    LaunchedEffect(key1 = homeScreenState.listOfVisibleWorkoutsUiState) {
-        when (homeScreenState.listOfVisibleWorkoutsUiState) {
-            UiState.None -> {
-                homeScreenState.homeScreenEvents(HomeScreenEvents.CollectRealmWorkoutEntryFromDb)
-            }
-
-            else -> Unit
-        }
+    LaunchedEffect(key1 = true) {
+        homeScreenState.homeScreenEvents(HomeScreenEvents.SyncRealmWorkoutEntryFromDb)
     }
 
     val isDatePickerDialogShowing by rememberSaveable(homeScreenState.isDatePickerDialogShowing) {

--- a/app/src/main/java/com/example/fitjournal/home/presentation/screen/home/HomeScreenViewModel.kt
+++ b/app/src/main/java/com/example/fitjournal/home/presentation/screen/home/HomeScreenViewModel.kt
@@ -208,9 +208,11 @@ class HomeScreenViewModel @Inject constructor(
 
     // should be call on load or when needed for loading screen
     private fun getDataFromRealmDb() {
-        updateHomeScreenState(newHomeScreenState = homeScreenState.copy(
-            listOfVisibleWorkoutsUiState = UiState.Loading
-        ))
+        updateHomeScreenState(
+            newHomeScreenState = homeScreenState.copy(
+                listOfVisibleWorkoutsUiState = UiState.Loading
+            )
+        )
         viewModelScope.launch {
             val masterWorkoutList = realmWorkoutEntryUseCase.getRealmWorkoutEntryList()
             if (masterWorkoutList.isNotEmpty()) {

--- a/app/src/main/java/com/example/fitjournal/home/presentation/screen/home/HomeScreenViewModel.kt
+++ b/app/src/main/java/com/example/fitjournal/home/presentation/screen/home/HomeScreenViewModel.kt
@@ -55,9 +55,15 @@ class HomeScreenViewModel @Inject constructor(
             HomeScreenEvents.DismissDatePicker -> updateDatePickerDialog(
                 isDatePickerShowing = false
             )
+
             HomeScreenEvents.ClearFilterExercisesDialog -> clearFilter()
             HomeScreenEvents.CollectRealmWorkoutEntryFromDb -> getDataFromRealmDb()
-            HomeScreenEvents.SyncRealmWorkoutEntryFromDb -> getDataFromRealmDb()
+            HomeScreenEvents.SyncRealmWorkoutEntryFromDb -> {
+                val shouldSyncOccur = realmWorkoutEntryUseCase.SyncDbWithViewModelUseCase()
+                if (shouldSyncOccur) {
+                    getDataFromRealmDb()
+                }
+            }
         }
     }
 
@@ -202,6 +208,9 @@ class HomeScreenViewModel @Inject constructor(
 
     // should be call on load or when needed for loading screen
     private fun getDataFromRealmDb() {
+        updateHomeScreenState(newHomeScreenState = homeScreenState.copy(
+            listOfVisibleWorkoutsUiState = UiState.Loading
+        ))
         viewModelScope.launch {
             val masterWorkoutList = realmWorkoutEntryUseCase.getRealmWorkoutEntryList()
             if (masterWorkoutList.isNotEmpty()) {
@@ -229,14 +238,5 @@ class HomeScreenViewModel @Inject constructor(
                 )
             }
         }
-    }
-
-    fun clearUiState() {
-        updateHomeScreenState(
-            newHomeScreenState =
-            homeScreenState.copy(
-                listOfVisibleWorkoutsUiState = UiState.None
-            )
-        )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="title_edit_workout_error">Sorry, the workout you selected could not be found</string>
     <string name="title_add_workout_error">Sorry, the workout you selected can not be added to your journal. Please go back and try again.</string>
     <string name="title_delete_workout">Are you sure you want to delete \"%1$s\"</string>
+    <string name="title_no_workouts_added">No workouts added yet</string>
 
     // SubTitle Strings
     <string name="subtitle_filter_workouts_description">Select which type of exercises to show in your Fit Journal</string>


### PR DESCRIPTION
## Feature/Adjust Home Screen UI

## Bug/Feature description
- Splash Screen runs entire progress then navigates to home screen
- added Screens for empty, loading none and error states for home screen
- created additional navigation button for home screen so user can add to journal from list
- now passing date to add journal screens so user can add to journal for the current date they were looking at

## Solution description
Describe in detail your solution involved with the PR.

## Code Validations 
[X] PR is under 400 lines of code Insertion and Deletion  
[X] Files are Formatted and Optimized  
[X] Clean Architecture followed  
[X] No unneccessary comments or TODOs left in codebase  
[ ] Unit Tests Added  
[ ] Unit Tests NOT added and explanation why under exemption description  
[ ] UI Tests Added  
[ ] UI Tests NOT added and explanation why under exemption description  
[ ] End to End Tests Added  
[ ] End to End Tests NOT added and explanation why under exemption description  
[X] Screenshot of UI added  

## Exemption Definition
Explain if necessary the reason for any exemptions

## UI Screenshots 
![Home_Screen_Adjustments_part_1](https://github.com/Alex-A-Fit/FitJournal-Android/assets/64118964/da043536-82fa-4ad3-97da-2dfd717097e9)
![Home_Screen_Adjustments_part_2](https://github.com/Alex-A-Fit/FitJournal-Android/assets/64118964/efa655a1-94bd-4a99-8fd2-6d5687f65a80)

**Selecting a different date to add to journal. We will select a workout from the add journal screen and navigate to addJournalDetailsScreen**
![Home_Screen_Adjustments_part_3](https://github.com/Alex-A-Fit/FitJournal-Android/assets/64118964/08052abc-634c-43ea-9adf-98facfb33714)
**Date persists through navigation**
![Home_Screen_Adjustments_part_4](https://github.com/Alex-A-Fit/FitJournal-Android/assets/64118964/c11f4740-79b6-41b9-8805-6a962d3ec5ac)

## Test Case Screenshots
Place test Success creations here
